### PR TITLE
Beginnings Of sr25 Support

### DIFF
--- a/usda/management/commands/unicode_dict_reader.py
+++ b/usda/management/commands/unicode_dict_reader.py
@@ -1,0 +1,24 @@
+import csv, codecs
+
+"""
+Adapted from the csv examples:
+
+http://docs.python.org/2/library/csv.html#csv-examples
+"""
+
+class UnicodeDictReader:
+    """
+    A UnicodeDictReader which will iterate over lines in the CSV file "f",
+    which is encoded in the given encoding, decoding each field entry to
+    unicode.
+    """
+    def __init__(self, f, dialect=csv.excel, fieldnames=None, restkey=None, restval=None, encoding="utf-8", *args, **kwds):
+        self._encoding = encoding
+        self._reader = csv.DictReader(f, dialect=dialect, fieldnames=fieldnames, restkey=restkey, restval=restval, *args, **kwds)
+
+    def next(self):
+        row = self._reader.next()
+        return dict(zip(row.keys(), [codecs.decode(s, self._encoding) for s in row.values()]))
+
+    def __iter__(self):
+        return self


### PR DESCRIPTION
First off, great project. I was going to create something in the same vein and was happy to see that I could spend my time on other things. But, I wanted to use the latest usda file (sr25) and the existing import command failed because of cp1252 characters that have found their way into the latest files.

This change converts the dict entries to unicode on the fly by decoding each entry from cp1252. I'm only doing this conversion on the FOOD_DES and NUTR_DEF files, because those are the only 2 with special cp1252 characters in sr25.

Please take a look and let me know what you think. I'd be happy to test this change on sr23-sr25 and update the README etc... to indicate a wider range of support.
