### PR TITLE
add missing comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url='http://github.com/notanumber/django-usda',
     license='http://www.opensource.org/licenses/bsd-license.php',
     packages=[
-        'usda'
+        'usda',
         'usda.management',
         'usda.management.commands',
     ],


### PR DESCRIPTION
There's a missing comma in setup.py that causes `python setup.py install` to fallover badly.
